### PR TITLE
Add new post search endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     expose:
       - 27017
     ports:
-      - 27017:27017
+      - 127.0.0.1:27017:27017
     restart: always
     entrypoint: [ "/usr/bin/mongod", "--bind_ip_all"]
     # You probably want to uncomment this and persist outside of the container

--- a/tagging/api.py
+++ b/tagging/api.py
@@ -11,6 +11,7 @@ from .graphql import schema, set_gql_tag_service
 
 from .model import (
     Dataset,
+    SearchDatasetsRequest,
     Tag,
     TagSource,
     TaggingEvent,
@@ -83,6 +84,26 @@ def add_dataset(dataset: Dataset):
     return CreateResponseModel(uid=new_dataset.uid)
 
 
+@app.post(API_URL_PREFIX + '/datasets/search', tags=['datasets'], response_model=List[Dataset])
+def search_datasets(
+    search: SearchDatasetsRequest,
+    offset: Optional[int] = FastQuery(0, alias="page[offset]"),
+    limit: Optional[int] = FastQuery(DEFAULT_PAGE_SIZE, alias="page[limit]")
+
+) -> List[Dataset]:
+    """ Searches datasets based on query parameters. Provides pagine through skip and limit
+    Args:
+        uri (Optional[str], optional): find dataset based on uri. Defaults to None.
+        tags(Optional[List[str]], optional): list of tags to search for. Defaults to none.
+        skip (Optional[int], optional): [description]. Defaults to 0.
+        limit (Optional[int], optional): [description]. Defaults to 10.
+
+    Returns:
+        List[Dataset]: [Full object datasets corresponding to search parameters]
+    """
+    return tag_svc.find_datasets(offset=offset, limit=limit, uris=search.uris, tags=search.tags)
+
+
 @app.get(API_URL_PREFIX + '/datasets', tags=['datasets'], response_model=List[Dataset])
 def get_datasets(
     uris: Optional[List[str]] = FastQuery(None),
@@ -102,7 +123,6 @@ def get_datasets(
         List[Dataset]: [Full object datasets corresponding to search parameters]
     """
     return tag_svc.find_datasets(offset=offset, limit=limit, uris=uris, tags=tags)
-
 
 @app.patch(API_URL_PREFIX + '/datasets/{uid}/tags',
            tags=['datasets', 'tags'],

--- a/tagging/api.py
+++ b/tagging/api.py
@@ -124,6 +124,7 @@ def get_datasets(
     """
     return tag_svc.find_datasets(offset=offset, limit=limit, uris=uris, tags=tags)
 
+
 @app.patch(API_URL_PREFIX + '/datasets/{uid}/tags',
            tags=['datasets', 'tags'],
            response_model=CreateTagPatchResponse)

--- a/tagging/model.py
+++ b/tagging/model.py
@@ -76,6 +76,11 @@ class FileDataset(Dataset):
     type = DatasetType.file
 
 
+class SearchDatasetsRequest(BaseModel):
+    uris: Optional[List[str]] = None
+    tags: Optional[List[str]] = None
+
+
 class TagPatchRequest(BaseModel):
     add_tags: Optional[List[Tag]]
     remove_tags: Optional[List[str]]

--- a/tagging/test/test_api.py
+++ b/tagging/test/test_api.py
@@ -4,6 +4,7 @@ from ..api import API_URL_PREFIX
 
 from ..model import (
     Dataset,
+    SearchDatasetsRequest,
     Tag,
     TagSource,
     TagPatchRequest
@@ -26,7 +27,16 @@ def test_tags_and_datasets(rest_client: TestClient):
     # search on name
     response: Dataset = rest_client.get(
         API_URL_PREFIX + "/datasets",
-        params={"offset": 0, "limit": 10, "type": "file", "uri": "/foo/bar.h5"})
+        params={"page[offset]": 0, "page[limit]": 10, "uri": "/foo/bar.h5"})
+    assert response.status_code == 200, f"oops {response.text}"
+    tag_sources = response.json()
+    assert len(tag_sources) == 1
+
+    # search on name using the post method
+    response: Dataset = rest_client.post(
+        API_URL_PREFIX + "/datasets/search",
+        params={"page[offset]": 0, "page[limit]": 10},
+        json={'uris': ['/foo/bar.h5']})
     assert response.status_code == 200, f"oops {response.text}"
     tag_sources = response.json()
     assert len(tag_sources) == 1

--- a/tagging/test/test_api.py
+++ b/tagging/test/test_api.py
@@ -4,7 +4,6 @@ from ..api import API_URL_PREFIX
 
 from ..model import (
     Dataset,
-    SearchDatasetsRequest,
     Tag,
     TagSource,
     TagPatchRequest


### PR DESCRIPTION
Adds a new endpoint to perform searches in post search. Still supports paging in query parameters to be consistent with get-style searching.

This addresses the problem that large searches, especially on URL, can overload the limit of url size.

Fixes #33 
